### PR TITLE
Add settings panel for theme selection, pixel size adjustment, and dark mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Isometric Pixel GitHub Graph",
   "version": "1.0",
   "description": "Browser extension for rendering an isometric pixel art version of your GitHub contribution graph.",
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "storage"],
   "background": {
     "service_worker": "background.js"
   },
@@ -13,5 +13,14 @@
       "js": ["content.js"],
       "css": ["styles.css"]
     }
-  ]
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "images/icon16.png",
+      "48": "images/icon48.png",
+      "128": "images/icon128.png"
+    }
+  },
+  "options_page": "settings.html"
 }

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <div class="graph-container" id="graphContainer"></div>
+  <a href="settings.html" target="_blank">Open Settings</a>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   fetchGraphData();
+  applyUserPreferences();
 });
 
 function fetchGraphData() {
@@ -23,10 +24,63 @@ function renderIsometricPixelArtGraph(data) {
 }
 
 function getColorForCount(count) {
-  // Define color mapping based on contribution count
+  const theme = getSelectedTheme();
+  if (theme) {
+    if (count >= 8) return theme.high;
+    if (count >= 6) return theme.mediumHigh;
+    if (count >= 4) return theme.medium;
+    if (count >= 2) return theme.low;
+    return theme.none;
+  }
+  // Default color mapping
   if (count >= 8) return '#216e39';
   if (count >= 6) return '#30a14e';
   if (count >= 4) return '#40c463';
   if (count >= 2) return '#9be9a8';
   return '#ebedf0';
+}
+
+function getSelectedTheme() {
+  const themes = {
+    default: {
+      high: '#216e39',
+      mediumHigh: '#30a14e',
+      medium: '#40c463',
+      low: '#9be9a8',
+      none: '#ebedf0'
+    },
+    dark: {
+      high: '#0e4429',
+      mediumHigh: '#006d32',
+      medium: '#26a641',
+      low: '#39d353',
+      none: '#161b22'
+    }
+  };
+  const selectedTheme = localStorage.getItem('selectedTheme') || 'default';
+  return themes[selectedTheme];
+}
+
+function applyUserPreferences() {
+  const pixelSize = localStorage.getItem('pixelSize') || '10px';
+  const darkMode = localStorage.getItem('darkMode') === 'true';
+
+  document.documentElement.style.setProperty('--pixel-size', pixelSize);
+  if (darkMode) {
+    document.documentElement.classList.add('dark-mode');
+  } else {
+    document.documentElement.classList.remove('dark-mode');
+  }
+}
+
+function saveUserPreferences() {
+  const pixelSize = document.getElementById('pixelSizeInput').value;
+  const selectedTheme = document.getElementById('themeSelect').value;
+  const darkMode = document.getElementById('darkModeToggle').checked;
+
+  localStorage.setItem('pixelSize', pixelSize);
+  localStorage.setItem('selectedTheme', selectedTheme);
+  localStorage.setItem('darkMode', darkMode);
+
+  applyUserPreferences();
 }

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Settings</h1>
+  <div>
+    <label for="themeSelect">Select Theme:</label>
+    <select id="themeSelect">
+      <option value="default">Default</option>
+      <option value="dark">Dark</option>
+    </select>
+  </div>
+  <div>
+    <label for="pixelSizeInput">Pixel Size:</label>
+    <input type="number" id="pixelSizeInput" min="1" max="20" value="10">
+  </div>
+  <div>
+    <label for="darkModeToggle">Dark Mode:</label>
+    <input type="checkbox" id="darkModeToggle">
+  </div>
+  <button onclick="saveUserPreferences()">Save</button>
+  <script src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  loadUserPreferences();
+});
+
+function loadUserPreferences() {
+  const pixelSize = localStorage.getItem('pixelSize') || '10';
+  const selectedTheme = localStorage.getItem('selectedTheme') || 'default';
+  const darkMode = localStorage.getItem('darkMode') === 'true';
+
+  document.getElementById('pixelSizeInput').value = pixelSize;
+  document.getElementById('themeSelect').value = selectedTheme;
+  document.getElementById('darkModeToggle').checked = darkMode;
+}
+
+function saveUserPreferences() {
+  const pixelSize = document.getElementById('pixelSizeInput').value;
+  const selectedTheme = document.getElementById('themeSelect').value;
+  const darkMode = document.getElementById('darkModeToggle').checked;
+
+  localStorage.setItem('pixelSize', pixelSize);
+  localStorage.setItem('selectedTheme', selectedTheme);
+  localStorage.setItem('darkMode', darkMode);
+
+  alert('Preferences saved!');
+}

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,21 @@
 /* Styles for the isometric pixel art graph */
+:root {
+  --pixel-size: 10px;
+  --theme-high: #216e39;
+  --theme-medium-high: #30a14e;
+  --theme-medium: #40c463;
+  --theme-low: #9be9a8;
+  --theme-none: #ebedf0;
+}
+
+.dark-mode {
+  --theme-high: #0e4429;
+  --theme-medium-high: #006d32;
+  --theme-medium: #26a641;
+  --theme-low: #39d353;
+  --theme-none: #161b22;
+}
+
 .graph-container {
   display: flex;
   justify-content: center;
@@ -9,9 +26,14 @@
 }
 
 .pixel {
-  width: 10px;
-  height: 10px;
+  width: var(--pixel-size);
+  height: var(--pixel-size);
   transform: rotate(45deg) skew(15deg);
-  background-color: #000;
+  background-color: var(--theme-none);
   margin: 1px;
+  transition: background-color 0.3s ease;
+}
+
+.pixel:hover {
+  background-color: var(--theme-high);
 }

--- a/themes.json
+++ b/themes.json
@@ -1,0 +1,16 @@
+{
+  "default": {
+    "high": "#216e39",
+    "mediumHigh": "#30a14e",
+    "medium": "#40c463",
+    "low": "#9be9a8",
+    "none": "#ebedf0"
+  },
+  "dark": {
+    "high": "#0e4429",
+    "mediumHigh": "#006d32",
+    "medium": "#26a641",
+    "low": "#39d353",
+    "none": "#161b22"
+  }
+}


### PR DESCRIPTION
Add a settings panel to the extension's popup for theme selection, pixel size adjustment, and dark mode toggle.

* **manifest.json**
  - Add `settings.html` to the `action` property to include the settings page.
  - Add `storage` permission to store user preferences.

* **popup.html**
  - Add a link to open the settings panel.

* **popup.js**
  - Add functions to handle theme selection, pixel size adjustment, and dark mode toggle.
  - Store user preferences in `localStorage` and apply them on page load.

* **styles.css**
  - Define multiple color themes and dark mode using CSS variables.
  - Add hover effects for the `.pixel` class.

* **settings.html**
  - Create the structure of the settings panel with elements for theme selection, pixel size adjustment, and dark mode toggle.

* **settings.js**
  - Handle the settings panel functionality, including saving and retrieving user preferences from `localStorage`.

* **themes.json**
  - Store different color themes for the isometric pixel art graph.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/isometric-pixel-contrib-graph/pull/7?shareId=7aaf4c19-3700-42c6-bd4d-487bd2ca38f4).