### PR TITLE
Allow users to export the isometric pixel art as an image or a GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,21 @@ Milestones are significant points in your contribution history, such as reaching
 3. Contribution streaks and milestones will be automatically highlighted in the graph.
 
 Enjoy tracking your progress and stay motivated with your contribution streaks and milestones!
+
+## Exporting the Isometric Pixel Art Graph
+
+This extension now includes functionality to export the isometric pixel art graph as an image or a GIF. Here's how you can use this feature:
+
+### Export as Image
+
+1. Open the extension popup to view your isometric pixel art contribution graph.
+2. Click the "Export as Image" button.
+3. The graph will be exported as a PNG image and downloaded to your device.
+
+### Export as GIF
+
+1. Open the extension popup to view your isometric pixel art contribution graph.
+2. Click the "Export as GIF" button.
+3. The graph will be exported as a GIF and downloaded to your device.
+
+This feature allows you to easily share your isometric pixel art contribution graph with others or save it for future reference.

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,9 @@
 </head>
 <body>
   <div class="graph-container" id="graphContainer"></div>
+  <canvas id="exportCanvas" style="display:none;"></canvas>
+  <button id="exportImageBtn">Export as Image</button>
+  <button id="exportGifBtn">Export as GIF</button>
   <a href="settings.html" target="_blank">Open Settings</a>
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   fetchGraphData();
   applyUserPreferences();
+  addExportEventListeners();
 });
 
 function fetchGraphData() {
@@ -86,4 +87,62 @@ function saveUserPreferences() {
   localStorage.setItem('darkMode', darkMode);
 
   applyUserPreferences();
+}
+
+function addExportEventListeners() {
+  document.getElementById('exportImageBtn').addEventListener('click', exportGraphAsImage);
+  document.getElementById('exportGifBtn').addEventListener('click', exportGraphAsGif);
+}
+
+function exportGraphAsImage() {
+  const canvas = document.getElementById('exportCanvas');
+  const ctx = canvas.getContext('2d');
+  const graphContainer = document.getElementById('graphContainer');
+  const pixels = graphContainer.getElementsByClassName('pixel');
+
+  canvas.width = graphContainer.offsetWidth;
+  canvas.height = graphContainer.offsetHeight;
+
+  Array.from(pixels).forEach(pixel => {
+    const rect = pixel.getBoundingClientRect();
+    ctx.fillStyle = pixel.style.backgroundColor;
+    ctx.fillRect(rect.left, rect.top, rect.width, rect.height);
+  });
+
+  const image = canvas.toDataURL('image/png');
+  const link = document.createElement('a');
+  link.href = image;
+  link.download = 'isometric-pixel-art.png';
+  link.click();
+}
+
+function exportGraphAsGif() {
+  const gif = new GIF({
+    workers: 2,
+    quality: 10
+  });
+
+  const canvas = document.getElementById('exportCanvas');
+  const ctx = canvas.getContext('2d');
+  const graphContainer = document.getElementById('graphContainer');
+  const pixels = graphContainer.getElementsByClassName('pixel');
+
+  canvas.width = graphContainer.offsetWidth;
+  canvas.height = graphContainer.offsetHeight;
+
+  Array.from(pixels).forEach(pixel => {
+    const rect = pixel.getBoundingClientRect();
+    ctx.fillStyle = pixel.style.backgroundColor;
+    ctx.fillRect(rect.left, rect.top, rect.width, rect.height);
+  });
+
+  gif.addFrame(ctx, {copy: true});
+  gif.on('finished', function(blob) {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'isometric-pixel-art.gif';
+    link.click();
+  });
+
+  gif.render();
 }


### PR DESCRIPTION
Add functionality to export the isometric pixel art graph as an image or GIF.

* **popup.html**
  - Add `canvas` element to render the graph for export.
  - Add buttons for exporting the graph as an image and as a GIF.

* **popup.js**
  - Add function to export the graph as an image using HTML5 Canvas API.
  - Add function to export the graph as a GIF using `gif.js` library.
  - Add event listeners to the new buttons to trigger the export functions.

* **README.md**
  - Add instructions on how to export the isometric pixel art graph as an image or a GIF.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/isometric-pixel-contrib-graph/pull/11?shareId=6f8abc23-c7f8-41c1-98e9-02a4337a83ed).